### PR TITLE
Adding monitoring agent to capture Tag setups through the Template

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -587,7 +587,10 @@ pixelIds.split(',').forEach(pixelId => {
     // If the user has chosen to disable pushState and replaceState tracking
     if (data.disablePushState) {
       setInWindow('fbq.disablePushState', true);
-    }  
+    }
+   	
+    // Monitoring agent string for Tag Setup	
+    fbq('set','agent','tmgoogletagmanager-simowebtemplate', pixelId);
     
     // Initialize pixel and store in global array
     fbq('init', pixelId, initObj);


### PR DESCRIPTION
Tested with creating a new with PR changes and firing the tag on the page. The agent string is added to the event parameters hence adding a way to monitor the Facebook event setup via Template.

![image](https://user-images.githubusercontent.com/2718218/91243009-b8d06180-e6fd-11ea-8240-1aa49684d8e3.png)
