### PR TITLE
Remove setting empty values for DPO

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -570,8 +570,6 @@ fbq('consent', consent);
  // Set Data Processing Options
 if (data.dpoLDU) {
   fbq('dataProcessingOptions', ['LDU'], makeNumber(data.dpoCountry), makeNumber(data.dpoState));
-} else {
-  fbq('dataProcessingOptions', []);
 }
 
 // Handle multiple, comma-separated pixel IDs,


### PR DESCRIPTION
Setting empty DPO-values triggers the Facebook Pixel Debugger to throw a warning. 
To avoid confusion skip setting empty values when DPO are not set in the tag.

![2020-08-26_14-16-40](https://user-images.githubusercontent.com/3629563/91337194-4cc02d00-e7d3-11ea-9297-770c3797a1b1.png)


Reference:
https://twitter.com/SimenHansenIO/status/1298595789309083649