### PR TITLE
feat: add Consent Mode v2 mapping and fallback protections for EEA compliance (v2.0.8)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.simoahava.com/"
 documentation: "https://www.simoahava.com/custom-templates/facebook-pixel"
 versions:
   # Latest version
+  - sha: d3a241e54cbf49af5232c9b89b85479ad2043a12
+    changeNotes: v2.0.8 Integrate Consent Mode v2 safety mappings, fallback to Data Processing Options when ad_storage or ad_user_data is denied.
+  # Older versions
   - sha: 9f1e02f54cbf49af5232c9b89b85479ad2043a11
     changeNotes: v2.0.7 Remove enable_reinit_cidparams2 GK and _fbq_gtm_cidparams_initialized window guard; always re-init pixels with cidParams when Advanced Matching data is present.
-  # Older versions
   - sha: ef36d6e324dc0f69a54ed3454204f5ea35bbe43b
     changeNotes: v2.0.6 Add Terms of Service.
   - sha: c40306cdfefe3a0267bf4b1b9d4190dca6a9693e


### PR DESCRIPTION
### Purpose
This PR introduces version 2.0.8, adding explicit fallback protections for Google Consent Mode v2 frameworks. 

### Key Changes
* Added SHA `d3a241e54cbf49af5232c9b89b85479ad2043a12` representing v2.0.8.
* Automatically bridges GTM `ad_storage` and `ad_user_data` states directly to Meta's Limited Data Use (LDU) / Data Processing Options flags if explicit consent data is missing or denied.
* Enhances regulatory compliance for enterprise deployments targeting users in the EU/EEA without breaking existing standard configurations.