### PR TITLE
fix(meta): use country parameter instead of cn

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -343,7 +343,7 @@ ___TEMPLATE_PARAMETERS___
               },
               {
                 "displayValue": "Country",
-                "value": "cn"
+                "value": "country"
               },
               {
                 "displayValue": "Date of Birth",


### PR DESCRIPTION
Updated the Meta Pixel / Conversions API mapping to send the country value using the country parameter instead of cn, aligning the implementation with Meta’s expected country field naming.